### PR TITLE
fix: match edgeR raw-f75 rule for TMM reference-column selection

### DIFF
--- a/amalgkit/normalization_tmm.py
+++ b/amalgkit/normalization_tmm.py
@@ -153,7 +153,22 @@ def _resolve_tmm_reference_column(matrix, lib_sizes):
         lib_size_values = lib_sizes.to_numpy(dtype=float)
     else:
         lib_size_values = numpy.asarray(lib_sizes, dtype=float).reshape(-1)
-    f75 = calc_factor_quantile(matrix, lib_size_values).to_numpy(dtype=float)
+    # edgeR's calcNormFactors selects the reference column from the RAW
+    # per-column 75th percentile (not divided by library size):
+    #   f75 <- apply(counts, 2, function(x) quantile(x, probs = 0.75))
+    #   refColumn <- which.min(abs(f75 - mean(f75)))
+    # Dividing by library size first changes which column is chosen whenever
+    # library sizes are heterogeneous, which silently changes every TMM factor
+    # (all factors are ratios to the reference).
+    if lib_size_values.size not in (1, matrix.shape[1]):
+        raise ValueError('lib_sizes must match the number of sample columns.')
+    f75 = numpy.asarray(
+        [
+            float(numpy.quantile(matrix[:, idx], q=0.75, method='linear'))
+            for idx in range(matrix.shape[1])
+        ],
+        dtype=float,
+    )
     if float(numpy.median(f75)) < 1e-20:
         ref_column = int(numpy.argmax(numpy.sum(numpy.sqrt(matrix), axis=0)))
     else:

--- a/tests/test_tmm_edger_parity.py
+++ b/tests/test_tmm_edger_parity.py
@@ -2,9 +2,75 @@ import numpy
 import pandas
 
 from amalgkit.normalization_tmm import (
+    _resolve_tmm_reference_column,
     apply_tmm_factors,
+    calc_norm_factors_tmm,
     run_tmm_rounds_for_cstmm,
 )
+
+
+def test_tmm_reference_column_matches_edger_raw_f75_rule():
+    # edgeR's calcNormFactors selects the reference from the RAW 75th
+    # percentile: f75 <- apply(counts, 2, quantile, probs = 0.75);
+    # refColumn <- which.min(abs(f75 - mean(f75))). Library sizes must NOT
+    # enter this selection. With heterogeneous library sizes the previous
+    # implementation (f75 divided by lib.size) picked a different column
+    # (391/500 randomized trials diverged from edgeR).
+    counts = pandas.DataFrame(
+        {
+            'SP1': [100, 200, 50, 10, 5, 1],
+            'SP2': [50, 400, 30, 8, 4, 2],
+            'SP3': [200, 100, 60, 12, 6, 3],
+            'SP4': [10, 20, 90, 5, 2, 1],
+        },
+        index=[f'G{i}' for i in range(1, 7)],
+    )
+    library_sizes = pandas.Series([1000.0, 2000.0, 500.0, 3000.0], index=list(counts.columns), dtype=float)
+
+    matrix = counts.to_numpy(dtype=float)
+    f75_raw = numpy.asarray(
+        [
+            float(numpy.quantile(matrix[:, idx], 0.75, method='linear'))
+            for idx in range(matrix.shape[1])
+        ],
+        dtype=float,
+    )
+    expected_ref = int(numpy.argmin(numpy.abs(f75_raw - numpy.mean(f75_raw))))
+
+    resolved = _resolve_tmm_reference_column(matrix, library_sizes.to_numpy(dtype=float))
+
+    assert resolved == expected_ref
+    # This fixture specifically exercises the divergence: the raw-f75 rule
+    # (edgeR) picks column 1, while the old f75/lib.size rule picked column 0.
+    assert expected_ref == 1
+    assert f75_raw[0] != f75_raw[1]
+
+
+def test_tmm_factors_golden_values_with_edger_reference_selection():
+    # Golden-value regression: factor values produced with the edgeR reference
+    # selection rule. Computed from a faithful reimplementation of edgeR's
+    # calcFactorTMM (log-ratio, average-expression, variance weights,
+    # quantile trimming floor(n*trim)+1 .. n+1-lo, 2^f) with the reference
+    # column chosen by the raw-f75 rule.
+    counts = pandas.DataFrame(
+        {
+            'SP1': [100, 200, 50, 10, 5, 1],
+            'SP2': [50, 400, 30, 8, 4, 2],
+            'SP3': [200, 100, 60, 12, 6, 3],
+            'SP4': [10, 20, 90, 5, 2, 1],
+        },
+        index=[f'G{i}' for i in range(1, 7)],
+    )
+    library_sizes = pandas.Series([1000.0, 2000.0, 500.0, 3000.0], index=list(counts.columns), dtype=float)
+
+    observed = calc_norm_factors_tmm(counts, lib_size=library_sizes, ref_column=None)
+
+    expected = pandas.Series(
+        [2.122576, 0.685809, 5.051604, 0.135989],
+        index=list(counts.columns),
+        dtype=float,
+    )
+    numpy.testing.assert_allclose(observed.to_numpy(dtype=float), expected.to_numpy(dtype=float), rtol=1e-5, atol=1e-5)
 
 
 def test_run_tmm_rounds_for_cstmm_returns_positive_factors_and_reference_columns():


### PR DESCRIPTION
## Summary
Fixes #170 (TMM reference-column selection deviates from edgeR: f75 divided by library size).

edgeR's `calcNormFactors` selects the TMM reference column from the **raw** per-column 75th percentile:

    f75 <- apply(counts, 2, function(x) quantile(x, probs = 0.75))
    refColumn <- which.min(abs(f75 - mean(f75)))

The previous implementation used `calc_factor_quantile`, which returns `f75 / lib.size`. With heterogeneous library sizes a different reference column was chosen (391/500 randomized trials diverged from edgeR), and because every TMM factor is a ratio to the reference, this silently changed all normalized counts and library-size scaling.

## Changes
- `amalgkit/normalization_tmm.py`: `_resolve_tmm_reference_column` now computes the raw per-column 0.75 quantile (edgeR rule) and validates `lib_sizes` shape. `calc_factor_quantile` semantics are unchanged for its RUVseq upper-quartile caller.
- `tests/test_tmm_edger_parity.py`: two new parity tests — (1) reference selection matches the edgeR raw-f75 rule on a fixture where the old rule diverged (picks column 1, old rule picked column 0); (2) factor values match golden values computed with the edgeR reference selection.

## Test plan
- `pytest -q` → 1357 passed, 2 skipped, 0 failed *except* the pre-existing `test_run_ruvseq_backend_rank_zero_returns_raw_counts_and_reports_k_zero` failure on master (statsmodels 0.14.6 GLM float-noise residuals), which is fixed by sibling PR #186.
- `ruff check .` → clean
- Version bumped 0.16.34 → 0.16.35

Closes #170
