### PR TITLE
fix: treat blank exclusion as not-excluded consistently in quant/merge/getfastq

### DIFF
--- a/amalgkit/getfastq.py
+++ b/amalgkit/getfastq.py
@@ -5749,8 +5749,11 @@ def filter_getfastq_eligible_metadata(metadata):
             .str.strip()
             .str.lower()
         )
-        if exclusion.ne('').any():
-            eligible_mask &= exclusion.eq('no')
+        # "no" means retained; blank/NA is treated as "no" (consistent with
+        # label_sampled_data in metadata_utils, build_quant_tasks in quant and
+        # collect_species_runs in merge). Any other value is an exclusion
+        # reason (e.g. low_nspots, no_cstmm_output) and excludes the run.
+        eligible_mask &= exclusion.isin({'', 'no'})
     if 'is_sampled' in metadata.df.columns:
         sampled = (
             metadata.df.loc[:, 'is_sampled']

--- a/amalgkit/merge.py
+++ b/amalgkit/merge.py
@@ -236,7 +236,10 @@ def collect_species_runs(metadata, sp):
     species_series = metadata.df.loc[:, 'scientific_name'].fillna('').astype(str).str.strip()
     is_sp = (species_series == sp)
     exclusion_series = metadata.df.loc[:, 'exclusion'].fillna('').astype(str).str.strip().str.lower()
-    is_sampled = (exclusion_series == 'no')
+    # Blank/NA exclusion is treated as "no" (retained), consistent with
+    # label_sampled_data (metadata_utils) and build_quant_tasks (quant).
+    # Previously a blank exclusion silently dropped the run from merge.
+    is_sampled = (exclusion_series.isin({'', 'no'}))
     is_target = (is_sp & is_sampled)
     sra_ids = collect_valid_run_ids(metadata.df.loc[is_target, 'run'].values)
     sampled_sra_ids = set(sra_ids)

--- a/amalgkit/quant.py
+++ b/amalgkit/quant.py
@@ -2114,8 +2114,13 @@ def build_quant_tasks(metadata):
     eligible_mask = pandas.Series(True, index=metadata.df.index)
     if 'exclusion' in metadata.df.columns:
         exclusion = metadata.df['exclusion'].fillna('').astype(str).str.strip().str.lower()
-        if exclusion.ne('').any():
-            eligible_mask &= exclusion.eq('no')
+        # "no" means retained; blank/NA is treated as "no" (consistent with
+        # label_sampled_data in metadata_utils and collect_species_runs in
+        # merge). Any other value is an exclusion reason (e.g. low_nspots,
+        # no_cstmm_output) and excludes the run. Previously a blank exclusion
+        # was silently dropped from quant whenever the column had any
+        # non-empty value, losing runs without a warning.
+        eligible_mask &= exclusion.isin({'', 'no'})
     if 'is_sampled' in metadata.df.columns:
         sampled = metadata.df['is_sampled'].fillna('').astype(str).str.strip().str.lower()
         if sampled.ne('').any():

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -5,6 +5,7 @@ import os
 from types import SimpleNamespace
 
 from amalgkit.merge import (
+    collect_species_runs,
     collect_valid_run_ids,
     generate_merge_plot_pdfs,
     merge_fastp_stats_into_metadata,
@@ -13,6 +14,31 @@ from amalgkit.merge import (
     scan_quant_abundance_paths,
 )
 from amalgkit.util import Metadata
+
+
+class TestCollectSpeciesRuns:
+    def test_blank_exclusion_is_treated_as_not_excluded(self):
+        # Regression for #173: a blank/NA exclusion means "not excluded" and
+        # must be retained, consistent with label_sampled_data and
+        # build_quant_tasks. Previously a blank exclusion silently dropped the
+        # run from merge.
+        metadata = Metadata.from_DataFrame(pandas.DataFrame({
+            'run': ['SRR001', 'SRR002', 'SRR003'],
+            'scientific_name': ['sp1', 'sp1', 'sp1'],
+            'exclusion': ['no', '', 'low_mapping_rate'],
+        }))
+        sra_ids, sampled_sra_ids = collect_species_runs(metadata, 'sp1')
+        assert sra_ids == ['SRR001', 'SRR002']
+        assert sampled_sra_ids == {'SRR001', 'SRR002'}
+
+    def test_exclusion_reason_excludes_run(self):
+        metadata = Metadata.from_DataFrame(pandas.DataFrame({
+            'run': ['SRR001', 'SRR002'],
+            'scientific_name': ['sp1', 'sp1'],
+            'exclusion': ['no', 'no_cstmm_output'],
+        }))
+        sra_ids, _sampled_sra_ids = collect_species_runs(metadata, 'sp1')
+        assert sra_ids == ['SRR001']
 
 
 class TestMergeFastpStatsIntoMetadata:

--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -1054,6 +1054,21 @@ class TestQuantEdgeCases:
         assert build_quant_tasks(metadata) == [('SRR001', 'Species A')]
         assert metadata.df['run'].tolist() == ['SRR001']
 
+    def test_build_quant_tasks_keeps_blank_exclusion_when_column_mixed(self):
+        # Regression for #173: a blank/NA exclusion means "not excluded" and
+        # must be retained even when other rows carry an exclusion reason.
+        # Previously a blank exclusion was silently dropped whenever the
+        # column had any non-empty value.
+        metadata = Metadata.from_DataFrame(pandas.DataFrame({
+            'run': ['SRR001', 'SRR002', 'SRR003'],
+            'scientific_name': ['Species A', 'Species A', 'Species A'],
+            'exclusion': ['no', '', 'low_nspots'],
+            'is_sampled': ['yes', 'yes', 'yes'],
+        }))
+
+        assert build_quant_tasks(metadata) == [('SRR001', 'Species A'), ('SRR002', 'Species A')]
+        assert metadata.df['run'].tolist() == ['SRR001', 'SRR002']
+
     def test_build_quant_tasks_rejects_invalid_sampling_flag(self):
         metadata = Metadata.from_DataFrame(pandas.DataFrame({
             'run': ['SRR001'],


### PR DESCRIPTION
## Summary
Fixes #173 (Rows with empty `exclusion` are silently dropped from quant and merge whenever the column has any non-empty value).

`build_quant_tasks` (quant.py), `collect_species_runs` (merge.py) and `filter_getfastq_eligible_metadata` (getfastq.py) all dropped rows with a blank/NA exclusion whenever the exclusion column had any non-empty value (`if exclusion.ne('').any(): eligible_mask &= exclusion.eq('no')`). A run whose exclusion was left unfilled was therefore silently lost from quant and merge with no warning.

## Changes
- The pipeline convention (established by `label_sampled_data` in metadata_utils, which fills blank exclusion with `'no'`) is: `'no'` means retained, any other value is an exclusion reason (e.g. `low_nspots`, `no_cstmm_output`), and blank/NA means not excluded. All three functions now implement that convention: blank/NA is retained, non-`'no'` values exclude.
- Regression tests:
  - `tests/test_quant.py`: mixed blank/reason column keeps the blank-exclusion run.
  - `tests/test_merge.py`: blank exclusion retained, exclusion reason excludes (new `TestCollectSpeciesRuns` class).

## Test plan
- `pytest -q` → 1368 passed, 2 skipped, 0 failed *except* the pre-existing `test_run_ruvseq_backend_rank_zero_returns_raw_counts_and_reports_k_zero` failure on master (fixed by sibling PR #186).
- `ruff check .` → clean
- Version bumped 0.16.39 → 0.16.40

Closes #173
