### PR TITLE
fix(quant): mark oarfish eff_length as annotated length, not effective

### DIFF
--- a/amalgkit/output_contracts.py
+++ b/amalgkit/output_contracts.py
@@ -10,6 +10,12 @@ from collections.abc import Iterable, Sequence
 import numpy
 import pandas
 
+# Quant abundance table contract. Every producer (kallisto, oarfish) must emit
+# these columns. For kallisto, "eff_length" is a true effective length. oarfish
+# has no notion of effective length (long-read protocols have no fragment-length
+# bias) and emits the annotated transcript length in that column instead; the
+# run-info JSON records "eff_length_source" as "annotated_length" (oarfish) or
+# "effective_length" (a producer that provided a genuine effective length).
 QUANT_ABUNDANCE_REQUIRED_COLUMNS = (
     "target_id",
     "length",
@@ -137,6 +143,12 @@ def validate_quant_run_info_json(path: str) -> str:
         return 'quant run info JSON has an invalid "p_pseudoaligned" value.'
     if not math.isfinite(value) or value < 0.0 or value > 100.0:
         return f'quant run info JSON has out-of-range "p_pseudoaligned": {value}'
+    eff_length_source = payload.get("eff_length_source")
+    if eff_length_source is not None and eff_length_source not in {
+        "annotated_length",
+        "effective_length",
+    }:
+        return 'quant run info JSON has an invalid "eff_length_source" value.'
     return ""
 
 

--- a/amalgkit/quant.py
+++ b/amalgkit/quant.py
@@ -612,6 +612,11 @@ def _normalize_oarfish_quant_columns(quant_df):
             rename_map[column_name] = 'target_id'
         elif normalized in {'len', 'length'}:
             rename_map[column_name] = 'length'
+        elif normalized in {'efflength', 'effectivelength', 'effective_length'}:
+            # oarfish bulk output currently reports only the annotated length and
+            # has no notion of effective length, but if a genuine effective-length
+            # column is ever emitted, preserve it instead of fabricating it below.
+            rename_map[column_name] = 'eff_length'
         elif normalized in {'numreads', 'numread', 'estcounts', 'estcount'}:
             rename_map[column_name] = 'est_counts'
         elif normalized == 'tpm':
@@ -677,10 +682,30 @@ def adapt_oarfish_outputs(output_dir, sra_id, sra_stat, output_prefix, seq_tech)
     else:
         tpm = pandas.Series(_compute_compatibility_tpm(est_counts.to_numpy(), lengths.to_numpy()))
 
+    if 'eff_length' in quant_df.columns:
+        eff_length = pandas.to_numeric(quant_df['eff_length'], errors='coerce')
+        eff_length_values = eff_length.to_numpy(dtype=float)
+        if eff_length.isna().any() or not numpy.isfinite(eff_length_values).all():
+            raise ValueError(
+                'oarfish quant output contains non-finite values in eff_length.'
+            )
+        if (eff_length < 0).any():
+            raise ValueError(
+                'oarfish quant output contains negative values in eff_length.'
+            )
+        eff_length_source = 'effective_length'
+    else:
+        # oarfish has no notion of effective length (long-read protocols have
+        # no fragment-length bias), so the annotated length is the appropriate
+        # denominator. It is NOT a true effective length; flag this in the
+        # run-info so consumers can tell it apart from a real one.
+        eff_length = lengths
+        eff_length_source = 'annotated_length'
+
     abundance_df = pandas.DataFrame({
         'target_id': target_ids,
         'length': lengths,
-        'eff_length': lengths,
+        'eff_length': eff_length,
         'est_counts': est_counts,
         'tpm': tpm,
     })
@@ -708,6 +733,7 @@ def adapt_oarfish_outputs(output_dir, sra_id, sra_stat, output_prefix, seq_tech)
     p_pseudoaligned = mapped_reads / total_reads * 100.0
     run_info = dict(meta_info)
     run_info['quant_backend'] = 'oarfish'
+    run_info['eff_length_source'] = eff_length_source
     run_info['oarfish_seq_tech'] = seq_tech
     run_info['num_processed'] = total_reads
     run_info['num_pseudoaligned'] = mapped_reads

--- a/tests/test_output_contracts.py
+++ b/tests/test_output_contracts.py
@@ -45,3 +45,21 @@ def test_quant_run_info_rejects_nonstandard_nonfinite_number(tmp_path):
     run_info.write_text('{"p_pseudoaligned": NaN}', encoding="utf-8")
 
     assert "out-of-range" in output_contracts.validate_quant_run_info_json(str(run_info))
+
+
+def test_quant_run_info_accepts_valid_eff_length_source(tmp_path):
+    run_info = tmp_path / "run_info.json"
+    run_info.write_text(
+        json.dumps({"p_pseudoaligned": 50, "eff_length_source": "annotated_length"}),
+        encoding="utf-8",
+    )
+    assert output_contracts.validate_quant_run_info_json(str(run_info)) == ""
+
+
+def test_quant_run_info_rejects_invalid_eff_length_source(tmp_path):
+    run_info = tmp_path / "run_info.json"
+    run_info.write_text(
+        json.dumps({"p_pseudoaligned": 50, "eff_length_source": "length"}),
+        encoding="utf-8",
+    )
+    assert "eff_length_source" in output_contracts.validate_quant_run_info_json(str(run_info))

--- a/tests/test_quant_outputs.py
+++ b/tests/test_quant_outputs.py
@@ -287,3 +287,66 @@ def test_adapt_oarfish_outputs_uses_utf8_for_json_io(tmp_path, monkeypatch):
 
     assert json.loads(run_info_path.read_text(encoding='utf-8'))['note'] == '葉'
     assert [encoding for _path, encoding in observed] == ['utf-8', 'utf-8']
+
+
+def _write_oarfish_quant(tmp_path, header, rows, meta='{}'):
+    output_prefix = tmp_path / 'SRR001'
+    output_prefix.with_suffix('.quant').write_text(header + '\n' + rows, encoding='utf-8')
+    output_prefix.with_suffix('.meta_info.json').write_text(meta, encoding='utf-8')
+    return output_prefix
+
+
+def test_adapt_oarfish_outputs_marks_annotated_eff_length_source(tmp_path):
+    output_prefix = _write_oarfish_quant(
+        tmp_path,
+        'tname\tlen\tnum_reads',
+        'tx1\t1000\t4\ntx2\t500\t1',
+    )
+    adapt_oarfish_outputs(
+        output_dir=str(tmp_path),
+        sra_id='SRR001',
+        sra_stat={'total_spot': 10},
+        output_prefix=str(output_prefix),
+        seq_tech='ont-cdna',
+    )
+    run_info = json.loads((tmp_path / 'SRR001_run_info.json').read_text(encoding='utf-8'))
+    assert run_info['eff_length_source'] == 'annotated_length'
+    abundance_df = pandas.read_csv(tmp_path / 'SRR001_abundance.tsv', sep='\t')
+    # oarfish has no effective length; the column carries the annotated length,
+    # which is not a genuine effective length.
+    assert (abundance_df['eff_length'] == abundance_df['length']).all()
+
+
+def test_adapt_oarfish_outputs_preserves_genuine_eff_length(tmp_path):
+    output_prefix = _write_oarfish_quant(
+        tmp_path,
+        'tname\tlen\teffective_length\tnum_reads',
+        'tx1\t1000\t900\t4\ntx2\t500\t450\t1',
+    )
+    adapt_oarfish_outputs(
+        output_dir=str(tmp_path),
+        sra_id='SRR001',
+        sra_stat={'total_spot': 10},
+        output_prefix=str(output_prefix),
+        seq_tech='ont-cdna',
+    )
+    run_info = json.loads((tmp_path / 'SRR001_run_info.json').read_text(encoding='utf-8'))
+    assert run_info['eff_length_source'] == 'effective_length'
+    abundance_df = pandas.read_csv(tmp_path / 'SRR001_abundance.tsv', sep='\t')
+    assert abundance_df['eff_length'].tolist() == [900, 450]
+
+
+def test_adapt_oarfish_outputs_rejects_nonfinite_genuine_eff_length(tmp_path):
+    output_prefix = _write_oarfish_quant(
+        tmp_path,
+        'tname\tlen\teff_length\tnum_reads',
+        'tx1\t1000\tnan\t4',
+    )
+    with pytest.raises(ValueError, match='non-finite values in eff_length'):
+        adapt_oarfish_outputs(
+            output_dir=str(tmp_path),
+            sra_id='SRR001',
+            sra_stat={'total_spot': 10},
+            output_prefix=str(output_prefix),
+            seq_tech='ont-cdna',
+        )


### PR DESCRIPTION
## Summary
Fixes a producer/consumer schema mismatch: the oarfish adaptor filled the declared
eff_length column with raw transcript length (oarfish has no effective-length notion),
undisclosed to downstream consumers that divide counts by eff_length.

## Change
- Keep the annotated length as the model-appropriate denominator (emitting NaN would be
  destructive to TPM/FPKM normalization).
- Add a run_info.json eff_length_source marker (annotated_length vs effective_length).
- Teach the normalizer to preserve a genuine effective-length column; validate the marker
  in output_contracts.validate_quant_run_info_json.

## Test
- Regression tests in tests/test_quant_outputs.py, tests/test_output_contracts.py.

## Validation
Targeted tests 145 passed; full suite green; ruff clean.
