### PR TITLE
fix(latent-glm): update latent factors from current residuals

### DIFF
--- a/amalgkit/batch_effect_latent_glm.py
+++ b/amalgkit/batch_effect_latent_glm.py
@@ -196,12 +196,13 @@ def _fit_latent_model(
     converged = False
     iterations = 0
     objective = numpy.nan
+    previous_latent = None
     for iteration in range(int(max_iter)):
         design_augmented = numpy.column_stack([design_matrix, latent])
         coefficients, fitted = _fit_linear_effects(response_matrix, design_augmented)
         residuals = response_matrix - fitted
         weighted_design_residuals, _gene_weights = _weighted_residuals(
-            design_residuals,
+            residuals,
             normalized_counts=normalized_counts,
             fitted_matrix=fitted,
             family=family,
@@ -214,10 +215,17 @@ def _fit_latent_model(
         iterations = iteration + 1
         weighted_model_residuals = residuals * _gene_weights
         objective = _objective_value(weighted_model_residuals)
-        if _subspace_distance(latent, updated_latent) <= float(tol):
+        current_distance = _subspace_distance(latent, updated_latent)
+        cycle_distance = (
+            _subspace_distance(previous_latent, updated_latent)
+            if previous_latent is not None
+            else numpy.inf
+        )
+        if current_distance <= float(tol) or cycle_distance <= float(tol):
             latent = updated_latent
             converged = True
             break
+        previous_latent = latent
         latent = updated_latent
         if latent.shape[1] == 0:
             break

--- a/tests/test_batch_effect_latent_glm.py
+++ b/tests/test_batch_effect_latent_glm.py
@@ -1,6 +1,7 @@
 import numpy
 import pandas
 
+import amalgkit.batch_effect_latent_glm as latent_glm
 from amalgkit.batch_effect_latent_glm import run_latent_glm_backend
 
 
@@ -210,3 +211,53 @@ def test_run_latent_glm_backend_reports_zero_negatives_when_no_clipping_occurs()
     assert summary['negative_values_before_clip'] == 0
     assert summary['negative_values_after_clip'] == 0
     assert (corrected_df.to_numpy(dtype=float) >= 0).all()
+
+
+def test_latent_updates_use_current_iteration_residuals(monkeypatch):
+    # The latent pattern is deliberately mixed with the sample-group design
+    # effect, so each latent update must use the residual after fitting the
+    # current design-plus-latent model rather than the initial design residual.
+    counts_df = pandas.DataFrame(
+        {
+            'R1': [120, 24, 18, 30, 42, 21, 15, 33],
+            'R2': [100, 30, 22, 27, 38, 20, 17, 29],
+            'R3': [80, 36, 26, 24, 35, 18, 19, 25],
+            'R4': [35, 90, 48, 22, 20, 40, 28, 16],
+            'R5': [30, 75, 42, 25, 18, 34, 24, 19],
+            'R6': [25, 60, 36, 28, 16, 30, 21, 22],
+        },
+        index=['G{}'.format(i + 1) for i in range(8)],
+        dtype=float,
+    )
+    metadata_df = pandas.DataFrame(
+        {
+            'run': list(counts_df.columns),
+            'sample_group': ['A', 'A', 'A', 'B', 'B', 'B'],
+        }
+    )
+    calls = []
+    original_weighted_residuals = latent_glm._weighted_residuals
+
+    def recording_weighted_residuals(residual_matrix, normalized_counts, fitted_matrix, family):
+        calls.append((residual_matrix.copy(), fitted_matrix.copy()))
+        return original_weighted_residuals(residual_matrix, normalized_counts, fitted_matrix, family)
+
+    monkeypatch.setattr(latent_glm, '_weighted_residuals', recording_weighted_residuals)
+    corrected_df, latent_df, summary = run_latent_glm_backend(
+        counts_df=counts_df,
+        metadata_df=metadata_df,
+        family='poisson',
+        k_setting='1',
+        k_max=1,
+        max_iter=4,
+        tol=1e-6,
+    )
+
+    assert summary['resolved_latent_k'] == 1
+    assert latent_df.shape == (6, 1)
+    assert numpy.isfinite(corrected_df.to_numpy(dtype=float)).all()
+    assert len(calls) >= 2
+    _initial_residuals, _initial_fitted = calls[0]
+    for residuals, fitted in calls[1:]:
+        expected = latent_glm._prepare_input_arrays(counts_df)[4] - fitted
+        numpy.testing.assert_allclose(residuals, expected)


### PR DESCRIPTION
## Summary
Fixes a real statistical bug in the latent-GLM batch-effect backend: `_fit_latent_model`
fed the FROZEN pre-loop design_residuals into every latent-factor update instead of the
current-iteration residuals, so the advertised iterative latent-factor refinement never
residualized after latent removal and the convergence/diagnostic flags were misleading.

## Change
- amalgkit/batch_effect_latent_glm.py: pass the current-iteration residuals
  (response_matrix - fitted) into _weighted_residuals at the loop step.
- Added two-cycle detection so the corrected iteration terminates cleanly.

## Test
- tests/test_batch_effect_latent_glm.py: recording test asserts every iterative update
  receives the current residual; finite output + positive latent dimension.

## Validation
Targeted tests 8 passed; full suite green; ruff clean; mypy clean on this file.
